### PR TITLE
refactor: inject styles to resolve style conflicts

### DIFF
--- a/console/src/components/bytemd.vue
+++ b/console/src/components/bytemd.vue
@@ -1,12 +1,57 @@
 <script setup lang="ts">
-import "bytemd/dist/index.css";
-import "github-markdown-css/github-markdown-light.css";
+import bytemdStyles from "bytemd/dist/index.css?raw";
+import markdownStyles from "github-markdown-css/github-markdown-light.css?raw";
 import { Editor } from "@bytemd/vue-next";
 import gfm from "@bytemd/plugin-gfm";
 import { pluginSlug, vim } from "../plugins";
 import { getProcessor } from "bytemd";
-import { watch, onMounted, ref } from "vue";
+import { watch, onMounted, ref, onUnmounted } from "vue";
 import math from "@bytemd/plugin-math";
+
+// inject styles to resolve stylesheet conflicts
+onMounted(() => {
+  const el: HTMLLinkElement | null = document.querySelector(
+    'style[data-source="plugin-bytemd"]'
+  );
+
+  if (el) {
+    return;
+  }
+
+  const styleElement = document.createElement("style");
+  styleElement.innerHTML = [
+    bytemdStyles,
+    markdownStyles,
+    `
+.bytemd {
+  height: 100%;
+  border: none;
+}
+.bytemd.bytemd-fullscreen {
+  z-index: 9999;
+}
+.bytemd .markdown-body ul {
+  list-style: disc;
+}
+.bytemd .markdown-body ol {
+  list-style: decimal;
+}
+`,
+  ].join("\n");
+  styleElement.setAttribute("data-source", "plugin-bytemd");
+  styleElement.setAttribute("type", "text/css");
+  document.head.append(styleElement);
+});
+
+onUnmounted(() => {
+  const el: HTMLLinkElement | null = document.querySelector(
+    'style[data-source="plugin-bytemd"]'
+  );
+
+  if (el) {
+    el.remove();
+  }
+});
 
 const plugins = ref([gfm(), pluginSlug(), math()]);
 
@@ -86,23 +131,3 @@ watch(
 <template>
   <Editor :value="raw" :plugins="plugins" @change="handleChange" />
 </template>
-<style lang="scss">
-.bytemd {
-  height: 100%;
-  border: none;
-
-  &.bytemd-fullscreen {
-    z-index: 9999;
-  }
-
-  .markdown-body {
-    ul {
-      list-style: disc;
-    }
-
-    ol {
-      list-style: decimal;
-    }
-  }
-}
-</style>


### PR DESCRIPTION
手动在 head 标签中注入编辑器的样式，以解决样式冲突的问题。可以实现仅在编辑器加载的时候才加载样式，并且不会影响到其他编辑器的样式。

/kind improvement

```release-note
None
```