### PR TITLE
chore: cleanup deprecated constructor for base plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('run.halo.tools.platform:plugin:2.8.0-SNAPSHOT')
+    implementation platform('run.halo.tools.platform:plugin:2.10.0-SNAPSHOT')
     compileOnly 'run.halo.app:api'
 
     testImplementation 'run.halo.app:api'

--- a/src/main/java/run/halo/bytemd/BytemdPlugin.java
+++ b/src/main/java/run/halo/bytemd/BytemdPlugin.java
@@ -1,10 +1,9 @@
 package run.halo.bytemd;
 
-import org.pf4j.PluginWrapper;
 import org.springframework.stereotype.Component;
-import run.halo.app.extension.Scheme;
-import run.halo.app.extension.SchemeManager;
+
 import run.halo.app.plugin.BasePlugin;
+import run.halo.app.plugin.PluginContext;
 
 /**
  * @author ryanwang
@@ -13,15 +12,7 @@ import run.halo.app.plugin.BasePlugin;
 @Component
 public class BytemdPlugin extends BasePlugin {
 
-    public BytemdPlugin(PluginWrapper wrapper) {
-        super(wrapper);
-    }
-
-    @Override
-    public void start() {
-    }
-
-    @Override
-    public void stop() {
+    public BytemdPlugin(PluginContext context) {
+        super(context);
     }
 }

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   enabled: true
   version: 1.1.1
-  requires: ">=2.1.0"
+  requires: ">=2.10.0"
   author:
     name: Halo OSS Team
     website: https://github.com/halo-dev


### PR DESCRIPTION
### What this PR does?
移除对已过时的 PluginWrapper 的引用

see also https://github.com/halo-dev/halo/pull/6243

```release-note
None
```