### PR TITLE
[codex] Support Mermaid rendering

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -19,6 +19,7 @@
     "axios": "^1.13.1",
     "bytemd": "^1.22.0",
     "github-markdown-css": "^5.8.1",
+    "mermaid": "^10.9.4",
     "rehype-slug": "^5.1.0",
     "vue": "^3.5.22"
   },

--- a/console/pnpm-lock.yaml
+++ b/console/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       github-markdown-css:
         specifier: ^5.8.1
         version: 5.8.1
+      mermaid:
+        specifier: ^10.9.4
+        version: 10.9.4
       rehype-slug:
         specifier: ^5.1.0
         version: 5.1.0
@@ -128,6 +131,9 @@ packages:
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
+
+  '@braintree/sanitize-url@6.0.4':
+    resolution: {integrity: sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==}
 
   '@bufbuild/protobuf@2.5.2':
     resolution: {integrity: sha512-foZ7qr0IsUBjzWIq+SuBLfdQCpJ1j8cTuNNT4owngTHoN5KsJb8L9t65fzz7SCeSWzescoOil/0ldqiL041ABg==}
@@ -738,6 +744,15 @@ packages:
   '@types/codemirror@5.60.16':
     resolution: {integrity: sha512-V/yHdamffSS075jit+fDxaOAmdP2liok8NSNJnAZfDJErzOheuygHZEhAJrfmk5TEyM32MhkZjwo/idX791yxw==}
 
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -1160,6 +1175,10 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
@@ -1173,6 +1192,9 @@ packages:
   core-js@3.46.0:
     resolution: {integrity: sha512-vDMm9B0xnqqZ8uSBpZ8sNtRtOdmfShrvT6h2TuQGLs0Is+cR0DYbj/KWP6ALVNbWPpqA/qPLoOuppJN07humpA==}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1184,6 +1206,160 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.10:
+    resolution: {integrity: sha512-qTCQmEhcynucuaZgY5/+ti3X/rnszKZhEQH/ZdWdtP1tA/y3VoHJzcVrO9pjjJCNpigfscAtoUB5ONcd2wNn0A==}
+
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
   de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
@@ -1206,6 +1382,9 @@ packages:
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -1232,12 +1411,18 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dompurify@3.1.6:
+    resolution: {integrity: sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
   electron-to-chromium@1.5.244:
     resolution: {integrity: sha512-OszpBN7xZX4vWMPJwB9illkN/znA8M36GQqQxi6MNy9axWxhOfJyZZJtSLQCpEFLHP2xK33BiWx9aIuIEXVCcw==}
+
+  elkjs@0.9.3:
+    resolution: {integrity: sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==}
 
   emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
@@ -1549,6 +1734,10 @@ packages:
   html-void-elements@2.0.1:
     resolution: {integrity: sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1570,6 +1759,13 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-buffer@2.0.5:
     resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
@@ -1638,12 +1834,22 @@ packages:
     resolution: {integrity: sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==}
     hasBin: true
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -1738,6 +1944,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mermaid@10.9.4:
+    resolution: {integrity: sha512-VIG2B0R9ydvkS+wShA8sXqkzfpYglM2Qwj7VyUeqzNVqSGPoP/tcaUr3ub4ESykv8eqQJn3p99bHNvYdg3gCHQ==}
 
   micromark-core-commonmark@1.1.0:
     resolution: {integrity: sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==}
@@ -1877,6 +2086,9 @@ packages:
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  non-layered-tidy-tree-layout@2.0.2:
+    resolution: {integrity: sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==}
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -2071,6 +2283,9 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rollup@4.52.5:
     resolution: {integrity: sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -2094,6 +2309,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
@@ -2103,6 +2321,9 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   sass-embedded-all-unknown@1.93.3:
     resolution: {integrity: sha512-3okGgnE41eg+CPLtAPletu6nQ4N0ij7AeW+Sl5Km4j29XcmqZQeFwYjHe1AlKTEgLi/UAONk1O8i8/lupeKMbw==}
@@ -2291,6 +2512,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2352,6 +2576,10 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
+
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
@@ -2409,6 +2637,11 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   uvu@0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
@@ -2521,6 +2754,9 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  web-worker@1.5.0:
+    resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
+
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
     engines: {node: '>=10.13.0'}
@@ -2586,6 +2822,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@braintree/sanitize-url@6.0.4': {}
 
   '@bufbuild/protobuf@2.5.2': {}
 
@@ -3110,6 +3348,14 @@ snapshots:
   '@types/codemirror@5.60.16':
     dependencies:
       '@types/tern': 0.23.9
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-time@3.0.4': {}
 
   '@types/debug@4.1.12':
     dependencies:
@@ -3639,6 +3885,8 @@ snapshots:
 
   commander@2.20.3: {}
 
+  commander@7.2.0: {}
+
   commander@8.3.0: {}
 
   computeds@0.0.1: {}
@@ -3646,6 +3894,10 @@ snapshots:
   concat-map@0.0.1: {}
 
   core-js@3.46.0: {}
+
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3656,6 +3908,187 @@ snapshots:
   cssesc@3.0.0: {}
 
   csstype@3.1.3: {}
+
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.10:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.17.21
+
+  dayjs@1.11.21: {}
 
   de-indent@1.0.2: {}
 
@@ -3670,6 +4103,10 @@ snapshots:
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   delayed-stream@1.0.0: {}
 
@@ -3688,6 +4125,8 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dompurify@3.1.6: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -3695,6 +4134,8 @@ snapshots:
       gopd: 1.2.0
 
   electron-to-chromium@1.5.244: {}
+
+  elkjs@0.9.3: {}
 
   emojis-list@3.0.0: {}
 
@@ -4085,6 +4526,10 @@ snapshots:
 
   html-void-elements@2.0.1: {}
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ignore@5.3.2: {}
 
   immutable@5.1.2: {}
@@ -4102,6 +4547,10 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   is-buffer@2.0.5: {}
 
@@ -4151,11 +4600,19 @@ snapshots:
     dependencies:
       commander: 8.3.0
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
 
+  khroma@2.1.0: {}
+
   kleur@4.1.5: {}
+
+  layout-base@1.0.2: {}
 
   levn@0.4.1:
     dependencies:
@@ -4311,6 +4768,31 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  mermaid@10.9.4:
+    dependencies:
+      '@braintree/sanitize-url': 6.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.10
+      dayjs: 1.11.21
+      dompurify: 3.1.6
+      elkjs: 0.9.3
+      katex: 0.16.47
+      khroma: 2.1.0
+      lodash-es: 4.17.21
+      mdast-util-from-markdown: 1.3.1
+      non-layered-tidy-tree-layout: 2.0.2
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 9.0.1
+      web-worker: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
 
   micromark-core-commonmark@1.1.0:
     dependencies:
@@ -4553,6 +5035,8 @@ snapshots:
 
   node-releases@2.0.27: {}
 
+  non-layered-tidy-tree-layout@2.0.2: {}
+
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
@@ -4793,6 +5277,8 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
+  robust-predicates@3.0.3: {}
+
   rollup@4.52.5:
     dependencies:
       '@types/estree': 1.0.8
@@ -4835,6 +5321,8 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  rw@1.3.3: {}
+
   rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
@@ -4844,6 +5332,8 @@ snapshots:
       mri: 1.2.0
 
   safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
 
   sass-embedded-all-unknown@1.93.3:
     dependencies:
@@ -5017,6 +5507,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  stylis@4.4.0: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -5067,6 +5559,8 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-dedent@2.3.0: {}
 
   tslib@1.14.1: {}
 
@@ -5131,6 +5625,8 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  uuid@9.0.1: {}
 
   uvu@0.5.6:
     dependencies:
@@ -5230,6 +5726,8 @@ snapshots:
       graceful-fs: 4.2.11
 
   web-namespaces@2.0.1: {}
+
+  web-worker@1.5.0: {}
 
   webpack-sources@3.3.3: {}
 

--- a/console/src/components/bytemd.vue
+++ b/console/src/components/bytemd.vue
@@ -1,7 +1,13 @@
 <script setup lang="ts">
 import { Editor } from "@bytemd/vue-next";
 import gfm from "@bytemd/plugin-gfm";
-import { markdownTable, pluginSlug, vim } from "../plugins";
+import {
+  markdownTable,
+  mermaidPlugin,
+  pluginSlug,
+  renderMermaidInHtml,
+  vim,
+} from "../plugins";
 import {
   getProcessor,
   type BytemdEditorContext,
@@ -19,6 +25,7 @@ import "../styles/main.scss";
 const basePlugins: BytemdPlugin[] = [
   gfm(),
   pluginSlug(),
+  mermaidPlugin(),
   math(),
   breaks(),
   {
@@ -43,6 +50,7 @@ const createPlugins = (useVimKeymap = false): BytemdPlugin[] => {
 };
 
 const plugins = ref<BytemdPlugin[]>(createPlugins());
+let contentRenderVersion = 0;
 
 const VIM_KEYMAP_NAME = "vim";
 
@@ -93,11 +101,16 @@ onMounted(async () => {
 
 watch(
   () => props.raw,
-  (value) => {
+  async (value) => {
+    const version = ++contentRenderVersion;
     const processor = getProcessor({ plugins: plugins.value }).processSync(
       value
     );
-    emit("update:content", processor.toString());
+    const content = await renderMermaidInHtml(processor.toString());
+
+    if (version === contentRenderVersion) {
+      emit("update:content", content);
+    }
   },
   {
     immediate: true,

--- a/console/src/plugins/index.ts
+++ b/console/src/plugins/index.ts
@@ -2,6 +2,7 @@ import type { BytemdPlugin, BytemdEditorContext } from "bytemd";
 import rehypeSlug from "rehype-slug";
 import useVim from "codemirror-ssr/keymap/vim";
 export { markdownTable } from "./markdown-table";
+export { mermaidPlugin, renderMermaidInHtml } from "./mermaid";
 
 export function pluginSlug(): BytemdPlugin {
   return {

--- a/console/src/plugins/mermaid.ts
+++ b/console/src/plugins/mermaid.ts
@@ -1,0 +1,227 @@
+import type { BytemdPlugin } from "bytemd";
+
+const MERMAID_SELECTOR = "pre > code.language-mermaid";
+const MERMAID_THEME_FALLBACKS = {
+  background: "white",
+  primaryColor: "#ECECFF",
+  primaryTextColor: "#131300",
+  primaryBorderColor: "hsl(240, 60%, 86.2745098039%)",
+  secondaryColor: "#ffffde",
+  secondaryTextColor: "#000021",
+  secondaryBorderColor: "hsl(60, 60%, 83.5294117647%)",
+  tertiaryColor: "hsl(80, 100%, 96.2745098039%)",
+  tertiaryTextColor: "rgb(6.3333333334, 0, 19.0000000001)",
+  tertiaryBorderColor: "hsl(80, 60%, 86.2745098039%)",
+  noteBkgColor: "#fff5ad",
+  noteTextColor: "black",
+  noteBorderColor: "#aaaa33",
+  lineColor: "#333333",
+  textColor: "#333",
+  mainBkg: "#ECECFF",
+  errorBkgColor: "#552222",
+  errorTextColor: "#552222",
+  nodeBorder: "#9370DB",
+  clusterBkg: "#ffffde",
+  clusterBorder: "#aaaa33",
+  defaultLinkColor: "#333333",
+  titleColor: "#333",
+  edgeLabelBackground: "#e8e8e8",
+  actorBkg: "#ECECFF",
+  actorBorder: "hsl(259.6261682243, 59.7765363128%, 87.9019607843%)",
+  actorTextColor: "black",
+  actorLineColor: "grey",
+  signalColor: "#333",
+  signalTextColor: "#333",
+  labelBoxBkgColor: "#ECECFF",
+  labelBoxBorderColor: "hsl(259.6261682243, 59.7765363128%, 87.9019607843%)",
+  labelTextColor: "black",
+  loopTextColor: "black",
+  activationBorderColor: "#666",
+  activationBkgColor: "#f4f4f4",
+  sequenceNumberColor: "white",
+  altBackground: "#f0f0f0",
+  classText: "#131300",
+  cScale0: "hsl(240, 100%, 76.2745098039%)",
+  cScale1: "hsl(60, 100%, 73.5294117647%)",
+  cScale2: "hsl(80, 100%, 76.2745098039%)",
+  cScale3: "hsl(270, 100%, 76.2745098039%)",
+  cScale4: "hsl(300, 100%, 76.2745098039%)",
+  cScale5: "hsl(330, 100%, 76.2745098039%)",
+  cScale6: "hsl(0, 100%, 76.2745098039%)",
+  cScale7: "hsl(30, 100%, 76.2745098039%)",
+  cScale8: "hsl(90, 100%, 76.2745098039%)",
+  cScale9: "hsl(150, 100%, 76.2745098039%)",
+  cScale10: "hsl(180, 100%, 76.2745098039%)",
+  cScale11: "hsl(210, 100%, 76.2745098039%)",
+  cScaleInv0: "hsl(60, 100%, 86.2745098039%)",
+  cScaleInv1: "hsl(240, 100%, 83.5294117647%)",
+  cScaleInv2: "hsl(260, 100%, 86.2745098039%)",
+  cScaleInv3: "hsl(90, 100%, 86.2745098039%)",
+  cScaleInv4: "hsl(120, 100%, 86.2745098039%)",
+  cScaleInv5: "hsl(150, 100%, 86.2745098039%)",
+  cScaleInv6: "hsl(180, 100%, 86.2745098039%)",
+  cScaleInv7: "hsl(210, 100%, 86.2745098039%)",
+  cScaleInv8: "hsl(270, 100%, 86.2745098039%)",
+  cScaleInv9: "hsl(330, 100%, 86.2745098039%)",
+  cScaleInv10: "hsl(0, 100%, 86.2745098039%)",
+  cScaleInv11: "hsl(30, 100%, 86.2745098039%)",
+  cScaleLabel0: "#ffffff",
+  cScaleLabel1: "black",
+  cScaleLabel2: "black",
+  cScaleLabel3: "#ffffff",
+  cScaleLabel4: "black",
+  cScaleLabel5: "black",
+  cScaleLabel6: "black",
+  cScaleLabel7: "black",
+  cScaleLabel8: "black",
+  cScaleLabel9: "black",
+  cScaleLabel10: "black",
+  cScaleLabel11: "black",
+};
+const MERMAID_THEME_VARIABLES = {
+  ...MERMAID_THEME_FALLBACKS,
+};
+const MERMAID_THEME_COLOR_REPLACEMENTS = Object.entries(
+  MERMAID_THEME_FALLBACKS
+).map(([key, color]) => {
+  return [color, `var(--bytemd-mermaid-${toKebabCase(key)}, ${color})`] as [
+    string,
+    string
+  ];
+});
+
+let renderId = 0;
+let initialized = false;
+let mermaidPromise: Promise<typeof import("mermaid").default> | undefined;
+
+async function getMermaid() {
+  if (!mermaidPromise) {
+    mermaidPromise = import("mermaid").then((module) => module.default);
+  }
+
+  return mermaidPromise;
+}
+
+async function initializeMermaid() {
+  const mermaid = await getMermaid();
+
+  if (initialized) {
+    return mermaid;
+  }
+
+  mermaid.initialize({
+    startOnLoad: false,
+    securityLevel: "strict",
+    theme: "base",
+    themeVariables: MERMAID_THEME_VARIABLES,
+  });
+  initialized = true;
+  return mermaid;
+}
+
+async function renderMermaidSvg(definition: string): Promise<string> {
+  const mermaid = await initializeMermaid();
+
+  const id = `bytemd-mermaid-${Date.now()}-${renderId++}`;
+  const { svg } = await mermaid.render(id, definition);
+  return replaceMermaidThemeColors(svg);
+}
+
+function replaceMermaidThemeColors(svg: string) {
+  return MERMAID_THEME_COLOR_REPLACEMENTS.reduce(
+    (result, [color, variable]) => {
+      return result.replace(new RegExp(escapeRegExp(color), "gi"), variable);
+    },
+    svg
+  );
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function toKebabCase(value: string) {
+  return value.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
+}
+
+async function renderMermaidElement(
+  codeElement: HTMLElement,
+  shouldRender: () => boolean = () => true
+) {
+  const container = codeElement.closest("pre");
+
+  if (!container) {
+    return;
+  }
+
+  const definition = codeElement.textContent || "";
+  const wrapper = document.createElement("div");
+  wrapper.className = "bytemd-mermaid";
+
+  try {
+    wrapper.innerHTML = await renderMermaidSvg(definition);
+  } catch {
+    wrapper.classList.add("bytemd-mermaid-error");
+    wrapper.textContent = "Mermaid render failed";
+  }
+
+  if (shouldRender()) {
+    container.replaceWith(wrapper);
+  }
+}
+
+export async function renderMermaidInHtml(html: string): Promise<string> {
+  if (!html.includes("language-mermaid")) {
+    return html;
+  }
+
+  const htmlDocument = new DOMParser().parseFromString(html, "text/html");
+  const codeElements = Array.from(
+    htmlDocument.body.querySelectorAll<HTMLElement>(MERMAID_SELECTOR)
+  );
+
+  await Promise.all(
+    codeElements.map(async (codeElement) => {
+      const container = codeElement.closest("pre");
+
+      if (!container) {
+        return;
+      }
+
+      try {
+        const wrapper = htmlDocument.createElement("div");
+        wrapper.className = "bytemd-mermaid";
+        wrapper.innerHTML = await renderMermaidSvg(
+          codeElement.textContent || ""
+        );
+        container.replaceWith(wrapper);
+      } catch {
+        // Keep the original code block when rendering fails.
+      }
+    })
+  );
+
+  return htmlDocument.body.innerHTML;
+}
+
+export function mermaidPlugin(): BytemdPlugin {
+  return {
+    viewerEffect({ markdownBody }) {
+      let disposed = false;
+      const codeElements = Array.from(
+        markdownBody.querySelectorAll<HTMLElement>(MERMAID_SELECTOR)
+      );
+
+      codeElements.forEach((codeElement) => {
+        renderMermaidElement(
+          codeElement,
+          () => !disposed && markdownBody.contains(codeElement)
+        );
+      });
+
+      return () => {
+        disposed = true;
+      };
+    },
+  };
+}

--- a/console/src/styles/main.scss
+++ b/console/src/styles/main.scss
@@ -14,3 +14,99 @@
 .bytemd .markdown-body ol {
   list-style: decimal;
 }
+.bytemd-mermaid {
+  --bytemd-mermaid-background: white;
+  --bytemd-mermaid-primary-color: #ececff;
+  --bytemd-mermaid-primary-text-color: #131300;
+  --bytemd-mermaid-primary-border-color: hsl(240, 60%, 86.2745098039%);
+  --bytemd-mermaid-secondary-color: #ffffde;
+  --bytemd-mermaid-secondary-text-color: #000021;
+  --bytemd-mermaid-secondary-border-color: hsl(60, 60%, 83.5294117647%);
+  --bytemd-mermaid-tertiary-color: hsl(80, 100%, 96.2745098039%);
+  --bytemd-mermaid-tertiary-text-color: rgb(6.3333333334, 0, 19.0000000001);
+  --bytemd-mermaid-tertiary-border-color: hsl(80, 60%, 86.2745098039%);
+  --bytemd-mermaid-note-bkg-color: #fff5ad;
+  --bytemd-mermaid-note-text-color: black;
+  --bytemd-mermaid-note-border-color: #aaaa33;
+  --bytemd-mermaid-line-color: #333333;
+  --bytemd-mermaid-text-color: #333;
+  --bytemd-mermaid-main-bkg: #ececff;
+  --bytemd-mermaid-error-bkg-color: #552222;
+  --bytemd-mermaid-error-text-color: #552222;
+  --bytemd-mermaid-node-border: #9370db;
+  --bytemd-mermaid-cluster-bkg: #ffffde;
+  --bytemd-mermaid-cluster-border: #aaaa33;
+  --bytemd-mermaid-default-link-color: #333333;
+  --bytemd-mermaid-title-color: #333;
+  --bytemd-mermaid-edge-label-background: #e8e8e8;
+  --bytemd-mermaid-actor-bkg: #ececff;
+  --bytemd-mermaid-actor-border: hsl(
+    259.6261682243,
+    59.7765363128%,
+    87.9019607843%
+  );
+  --bytemd-mermaid-actor-text-color: black;
+  --bytemd-mermaid-actor-line-color: grey;
+  --bytemd-mermaid-signal-color: #333;
+  --bytemd-mermaid-signal-text-color: #333;
+  --bytemd-mermaid-label-box-bkg-color: #ececff;
+  --bytemd-mermaid-label-box-border-color: hsl(
+    259.6261682243,
+    59.7765363128%,
+    87.9019607843%
+  );
+  --bytemd-mermaid-label-text-color: black;
+  --bytemd-mermaid-loop-text-color: black;
+  --bytemd-mermaid-activation-border-color: #666;
+  --bytemd-mermaid-activation-bkg-color: #f4f4f4;
+  --bytemd-mermaid-sequence-number-color: white;
+  --bytemd-mermaid-alt-background: #f0f0f0;
+  --bytemd-mermaid-class-text: #131300;
+  --bytemd-mermaid-c-scale0: hsl(240, 100%, 76.2745098039%);
+  --bytemd-mermaid-c-scale1: hsl(60, 100%, 73.5294117647%);
+  --bytemd-mermaid-c-scale2: hsl(80, 100%, 76.2745098039%);
+  --bytemd-mermaid-c-scale3: hsl(270, 100%, 76.2745098039%);
+  --bytemd-mermaid-c-scale4: hsl(300, 100%, 76.2745098039%);
+  --bytemd-mermaid-c-scale5: hsl(330, 100%, 76.2745098039%);
+  --bytemd-mermaid-c-scale6: hsl(0, 100%, 76.2745098039%);
+  --bytemd-mermaid-c-scale7: hsl(30, 100%, 76.2745098039%);
+  --bytemd-mermaid-c-scale8: hsl(90, 100%, 76.2745098039%);
+  --bytemd-mermaid-c-scale9: hsl(150, 100%, 76.2745098039%);
+  --bytemd-mermaid-c-scale10: hsl(180, 100%, 76.2745098039%);
+  --bytemd-mermaid-c-scale11: hsl(210, 100%, 76.2745098039%);
+  --bytemd-mermaid-c-scale-inv0: hsl(60, 100%, 86.2745098039%);
+  --bytemd-mermaid-c-scale-inv1: hsl(240, 100%, 83.5294117647%);
+  --bytemd-mermaid-c-scale-inv2: hsl(260, 100%, 86.2745098039%);
+  --bytemd-mermaid-c-scale-inv3: hsl(90, 100%, 86.2745098039%);
+  --bytemd-mermaid-c-scale-inv4: hsl(120, 100%, 86.2745098039%);
+  --bytemd-mermaid-c-scale-inv5: hsl(150, 100%, 86.2745098039%);
+  --bytemd-mermaid-c-scale-inv6: hsl(180, 100%, 86.2745098039%);
+  --bytemd-mermaid-c-scale-inv7: hsl(210, 100%, 86.2745098039%);
+  --bytemd-mermaid-c-scale-inv8: hsl(270, 100%, 86.2745098039%);
+  --bytemd-mermaid-c-scale-inv9: hsl(330, 100%, 86.2745098039%);
+  --bytemd-mermaid-c-scale-inv10: hsl(0, 100%, 86.2745098039%);
+  --bytemd-mermaid-c-scale-inv11: hsl(30, 100%, 86.2745098039%);
+  --bytemd-mermaid-c-scale-label0: #ffffff;
+  --bytemd-mermaid-c-scale-label1: black;
+  --bytemd-mermaid-c-scale-label2: black;
+  --bytemd-mermaid-c-scale-label3: #ffffff;
+  --bytemd-mermaid-c-scale-label4: black;
+  --bytemd-mermaid-c-scale-label5: black;
+  --bytemd-mermaid-c-scale-label6: black;
+  --bytemd-mermaid-c-scale-label7: black;
+  --bytemd-mermaid-c-scale-label8: black;
+  --bytemd-mermaid-c-scale-label9: black;
+  --bytemd-mermaid-c-scale-label10: black;
+  --bytemd-mermaid-c-scale-label11: black;
+  margin: 1rem 0;
+  overflow-x: auto;
+  text-align: center;
+}
+.bytemd-mermaid svg {
+  max-width: 100%;
+  height: auto;
+}
+.bytemd-mermaid-error {
+  color: #b91c1c;
+  text-align: left;
+}

--- a/src/main/java/run/halo/bytemd/BytemdHeadProcessor.java
+++ b/src/main/java/run/halo/bytemd/BytemdHeadProcessor.java
@@ -1,0 +1,271 @@
+package run.halo.bytemd;
+
+import org.springframework.stereotype.Component;
+import org.thymeleaf.context.ITemplateContext;
+import org.thymeleaf.model.IModel;
+import org.thymeleaf.processor.element.IElementModelStructureHandler;
+import reactor.core.publisher.Mono;
+import run.halo.app.theme.dialect.TemplateHeadProcessor;
+
+@Component
+public class BytemdHeadProcessor implements TemplateHeadProcessor {
+
+    @Override
+    public Mono<Void> process(ITemplateContext context, IModel model,
+                              IElementModelStructureHandler structureHandler) {
+        model.add(context.getModelFactory().createText(mermaidStyle()));
+        return Mono.empty();
+    }
+
+    private String mermaidStyle() {
+        return """
+            <!-- plugin-bytemd mermaid start -->
+            <style>
+            .bytemd-mermaid {
+              --bytemd-mermaid-background: white;
+              --bytemd-mermaid-primary-color: #ECECFF;
+              --bytemd-mermaid-primary-text-color: #131300;
+              --bytemd-mermaid-primary-border-color: hsl(240, 60%, 86.2745098039%);
+              --bytemd-mermaid-secondary-color: #ffffde;
+              --bytemd-mermaid-secondary-text-color: #000021;
+              --bytemd-mermaid-secondary-border-color: hsl(60, 60%, 83.5294117647%);
+              --bytemd-mermaid-tertiary-color: hsl(80, 100%, 96.2745098039%);
+              --bytemd-mermaid-tertiary-text-color: rgb(6.3333333334, 0, 19.0000000001);
+              --bytemd-mermaid-tertiary-border-color: hsl(80, 60%, 86.2745098039%);
+              --bytemd-mermaid-note-bkg-color: #fff5ad;
+              --bytemd-mermaid-note-text-color: black;
+              --bytemd-mermaid-note-border-color: #aaaa33;
+              --bytemd-mermaid-line-color: #333333;
+              --bytemd-mermaid-text-color: #333;
+              --bytemd-mermaid-main-bkg: #ECECFF;
+              --bytemd-mermaid-error-bkg-color: #552222;
+              --bytemd-mermaid-error-text-color: #552222;
+              --bytemd-mermaid-node-border: #9370DB;
+              --bytemd-mermaid-cluster-bkg: #ffffde;
+              --bytemd-mermaid-cluster-border: #aaaa33;
+              --bytemd-mermaid-default-link-color: #333333;
+              --bytemd-mermaid-title-color: #333;
+              --bytemd-mermaid-edge-label-background: #e8e8e8;
+              --bytemd-mermaid-actor-bkg: #ECECFF;
+              --bytemd-mermaid-actor-border: hsl(259.6261682243, 59.7765363128%, 87.9019607843%);
+              --bytemd-mermaid-actor-text-color: black;
+              --bytemd-mermaid-actor-line-color: grey;
+              --bytemd-mermaid-signal-color: #333;
+              --bytemd-mermaid-signal-text-color: #333;
+              --bytemd-mermaid-label-box-bkg-color: #ECECFF;
+              --bytemd-mermaid-label-box-border-color: hsl(259.6261682243, 59.7765363128%, 87.9019607843%);
+              --bytemd-mermaid-label-text-color: black;
+              --bytemd-mermaid-loop-text-color: black;
+              --bytemd-mermaid-activation-border-color: #666;
+              --bytemd-mermaid-activation-bkg-color: #f4f4f4;
+              --bytemd-mermaid-sequence-number-color: white;
+              --bytemd-mermaid-alt-background: #f0f0f0;
+              --bytemd-mermaid-class-text: #131300;
+              --bytemd-mermaid-c-scale0: hsl(240, 100%, 76.2745098039%);
+              --bytemd-mermaid-c-scale1: hsl(60, 100%, 73.5294117647%);
+              --bytemd-mermaid-c-scale2: hsl(80, 100%, 76.2745098039%);
+              --bytemd-mermaid-c-scale3: hsl(270, 100%, 76.2745098039%);
+              --bytemd-mermaid-c-scale4: hsl(300, 100%, 76.2745098039%);
+              --bytemd-mermaid-c-scale5: hsl(330, 100%, 76.2745098039%);
+              --bytemd-mermaid-c-scale6: hsl(0, 100%, 76.2745098039%);
+              --bytemd-mermaid-c-scale7: hsl(30, 100%, 76.2745098039%);
+              --bytemd-mermaid-c-scale8: hsl(90, 100%, 76.2745098039%);
+              --bytemd-mermaid-c-scale9: hsl(150, 100%, 76.2745098039%);
+              --bytemd-mermaid-c-scale10: hsl(180, 100%, 76.2745098039%);
+              --bytemd-mermaid-c-scale11: hsl(210, 100%, 76.2745098039%);
+              --bytemd-mermaid-c-scale-inv0: hsl(60, 100%, 86.2745098039%);
+              --bytemd-mermaid-c-scale-inv1: hsl(240, 100%, 83.5294117647%);
+              --bytemd-mermaid-c-scale-inv2: hsl(260, 100%, 86.2745098039%);
+              --bytemd-mermaid-c-scale-inv3: hsl(90, 100%, 86.2745098039%);
+              --bytemd-mermaid-c-scale-inv4: hsl(120, 100%, 86.2745098039%);
+              --bytemd-mermaid-c-scale-inv5: hsl(150, 100%, 86.2745098039%);
+              --bytemd-mermaid-c-scale-inv6: hsl(180, 100%, 86.2745098039%);
+              --bytemd-mermaid-c-scale-inv7: hsl(210, 100%, 86.2745098039%);
+              --bytemd-mermaid-c-scale-inv8: hsl(270, 100%, 86.2745098039%);
+              --bytemd-mermaid-c-scale-inv9: hsl(330, 100%, 86.2745098039%);
+              --bytemd-mermaid-c-scale-inv10: hsl(0, 100%, 86.2745098039%);
+              --bytemd-mermaid-c-scale-inv11: hsl(30, 100%, 86.2745098039%);
+              --bytemd-mermaid-c-scale-label0: #ffffff;
+              --bytemd-mermaid-c-scale-label1: black;
+              --bytemd-mermaid-c-scale-label2: black;
+              --bytemd-mermaid-c-scale-label3: #ffffff;
+              --bytemd-mermaid-c-scale-label4: black;
+              --bytemd-mermaid-c-scale-label5: black;
+              --bytemd-mermaid-c-scale-label6: black;
+              --bytemd-mermaid-c-scale-label7: black;
+              --bytemd-mermaid-c-scale-label8: black;
+              --bytemd-mermaid-c-scale-label9: black;
+              --bytemd-mermaid-c-scale-label10: black;
+              --bytemd-mermaid-c-scale-label11: black;
+              margin: 1rem 0;
+              overflow-x: auto;
+              text-align: center;
+            }
+            .bytemd-mermaid svg {
+              max-width: 100%;
+              height: auto;
+            }
+            @media (prefers-color-scheme: dark) {
+              .color-scheme-auto .bytemd-mermaid,
+              [data-color-scheme="auto"] .bytemd-mermaid {
+                --bytemd-mermaid-background: #333;
+                --bytemd-mermaid-primary-color: #1f2020;
+                --bytemd-mermaid-primary-text-color: #e0dfdf;
+                --bytemd-mermaid-primary-border-color: #cccccc;
+                --bytemd-mermaid-secondary-color: hsl(180, 1.5873015873%, 28.3529411765%);
+                --bytemd-mermaid-secondary-text-color: rgb(183.8476190475, 181.5523809523, 181.5523809523);
+                --bytemd-mermaid-secondary-border-color: hsl(180, 0%, 18.3529411765%);
+                --bytemd-mermaid-tertiary-color: hsl(20, 1.5873015873%, 12.3529411765%);
+                --bytemd-mermaid-tertiary-text-color: rgb(222.9999999999, 223.6666666666, 223.9999999999);
+                --bytemd-mermaid-tertiary-border-color: hsl(20, 0%, 2.3529411765%);
+                --bytemd-mermaid-note-bkg-color: hsl(180, 1.5873015873%, 28.3529411765%);
+                --bytemd-mermaid-note-text-color: rgb(183.8476190475, 181.5523809523, 181.5523809523);
+                --bytemd-mermaid-note-border-color: hsl(180, 0%, 18.3529411765%);
+                --bytemd-mermaid-line-color: lightgrey;
+                --bytemd-mermaid-text-color: #ccc;
+                --bytemd-mermaid-main-bkg: #1f2020;
+                --bytemd-mermaid-error-bkg-color: #a44141;
+                --bytemd-mermaid-error-text-color: #ddd;
+                --bytemd-mermaid-node-border: #81B1DB;
+                --bytemd-mermaid-cluster-bkg: hsl(180, 1.5873015873%, 28.3529411765%);
+                --bytemd-mermaid-cluster-border: rgba(255, 255, 255, 0.25);
+                --bytemd-mermaid-default-link-color: lightgrey;
+                --bytemd-mermaid-title-color: #F9FFFE;
+                --bytemd-mermaid-edge-label-background: hsl(0, 0%, 34.4117647059%);
+                --bytemd-mermaid-actor-bkg: #1f2020;
+                --bytemd-mermaid-actor-border: #81B1DB;
+                --bytemd-mermaid-actor-text-color: lightgrey;
+                --bytemd-mermaid-actor-line-color: lightgrey;
+                --bytemd-mermaid-signal-color: lightgrey;
+                --bytemd-mermaid-signal-text-color: lightgrey;
+                --bytemd-mermaid-label-box-bkg-color: #1f2020;
+                --bytemd-mermaid-label-box-border-color: #81B1DB;
+                --bytemd-mermaid-label-text-color: lightgrey;
+                --bytemd-mermaid-loop-text-color: lightgrey;
+                --bytemd-mermaid-activation-border-color: #81B1DB;
+                --bytemd-mermaid-activation-bkg-color: hsl(180, 1.5873015873%, 28.3529411765%);
+                --bytemd-mermaid-sequence-number-color: black;
+                --bytemd-mermaid-alt-background: #555;
+                --bytemd-mermaid-class-text: #e0dfdf;
+                --bytemd-mermaid-c-scale0: #1f2020;
+                --bytemd-mermaid-c-scale1: #0b0000;
+                --bytemd-mermaid-c-scale2: #4d1037;
+                --bytemd-mermaid-c-scale3: #3f5258;
+                --bytemd-mermaid-c-scale4: #4f2f1b;
+                --bytemd-mermaid-c-scale5: #6e0a0a;
+                --bytemd-mermaid-c-scale6: #3b0048;
+                --bytemd-mermaid-c-scale7: #995a01;
+                --bytemd-mermaid-c-scale8: #154706;
+                --bytemd-mermaid-c-scale9: #161722;
+                --bytemd-mermaid-c-scale10: #00296f;
+                --bytemd-mermaid-c-scale11: #01629c;
+                --bytemd-mermaid-c-scale-inv0: #e0dfdf;
+                --bytemd-mermaid-c-scale-inv1: #f4ffff;
+                --bytemd-mermaid-c-scale-inv2: #b2efc8;
+                --bytemd-mermaid-c-scale-inv3: #c0ada7;
+                --bytemd-mermaid-c-scale-inv4: #b0d0e4;
+                --bytemd-mermaid-c-scale-inv5: #91f5f5;
+                --bytemd-mermaid-c-scale-inv6: #c4ffb7;
+                --bytemd-mermaid-c-scale-inv7: #66a5fe;
+                --bytemd-mermaid-c-scale-inv8: #eab8f9;
+                --bytemd-mermaid-c-scale-inv9: #e9e8dd;
+                --bytemd-mermaid-c-scale-inv10: #ffd690;
+                --bytemd-mermaid-c-scale-inv11: #fe9d63;
+                --bytemd-mermaid-c-scale-label0: lightgrey;
+                --bytemd-mermaid-c-scale-label1: lightgrey;
+                --bytemd-mermaid-c-scale-label2: lightgrey;
+                --bytemd-mermaid-c-scale-label3: lightgrey;
+                --bytemd-mermaid-c-scale-label4: lightgrey;
+                --bytemd-mermaid-c-scale-label5: lightgrey;
+                --bytemd-mermaid-c-scale-label6: lightgrey;
+                --bytemd-mermaid-c-scale-label7: lightgrey;
+                --bytemd-mermaid-c-scale-label8: lightgrey;
+                --bytemd-mermaid-c-scale-label9: lightgrey;
+                --bytemd-mermaid-c-scale-label10: lightgrey;
+                --bytemd-mermaid-c-scale-label11: lightgrey;
+              }
+            }
+            .color-scheme-dark .bytemd-mermaid,
+            .dark .bytemd-mermaid,
+            [data-color-scheme="dark"] .bytemd-mermaid {
+              --bytemd-mermaid-background: #333;
+              --bytemd-mermaid-primary-color: #1f2020;
+              --bytemd-mermaid-primary-text-color: #e0dfdf;
+              --bytemd-mermaid-primary-border-color: #cccccc;
+              --bytemd-mermaid-secondary-color: hsl(180, 1.5873015873%, 28.3529411765%);
+              --bytemd-mermaid-secondary-text-color: rgb(183.8476190475, 181.5523809523, 181.5523809523);
+              --bytemd-mermaid-secondary-border-color: hsl(180, 0%, 18.3529411765%);
+              --bytemd-mermaid-tertiary-color: hsl(20, 1.5873015873%, 12.3529411765%);
+              --bytemd-mermaid-tertiary-text-color: rgb(222.9999999999, 223.6666666666, 223.9999999999);
+              --bytemd-mermaid-tertiary-border-color: hsl(20, 0%, 2.3529411765%);
+              --bytemd-mermaid-note-bkg-color: hsl(180, 1.5873015873%, 28.3529411765%);
+              --bytemd-mermaid-note-text-color: rgb(183.8476190475, 181.5523809523, 181.5523809523);
+              --bytemd-mermaid-note-border-color: hsl(180, 0%, 18.3529411765%);
+              --bytemd-mermaid-line-color: lightgrey;
+              --bytemd-mermaid-text-color: #ccc;
+              --bytemd-mermaid-main-bkg: #1f2020;
+              --bytemd-mermaid-error-bkg-color: #a44141;
+              --bytemd-mermaid-error-text-color: #ddd;
+              --bytemd-mermaid-node-border: #81B1DB;
+              --bytemd-mermaid-cluster-bkg: hsl(180, 1.5873015873%, 28.3529411765%);
+              --bytemd-mermaid-cluster-border: rgba(255, 255, 255, 0.25);
+              --bytemd-mermaid-default-link-color: lightgrey;
+              --bytemd-mermaid-title-color: #F9FFFE;
+              --bytemd-mermaid-edge-label-background: hsl(0, 0%, 34.4117647059%);
+              --bytemd-mermaid-actor-bkg: #1f2020;
+              --bytemd-mermaid-actor-border: #81B1DB;
+              --bytemd-mermaid-actor-text-color: lightgrey;
+              --bytemd-mermaid-actor-line-color: lightgrey;
+              --bytemd-mermaid-signal-color: lightgrey;
+              --bytemd-mermaid-signal-text-color: lightgrey;
+              --bytemd-mermaid-label-box-bkg-color: #1f2020;
+              --bytemd-mermaid-label-box-border-color: #81B1DB;
+              --bytemd-mermaid-label-text-color: lightgrey;
+              --bytemd-mermaid-loop-text-color: lightgrey;
+              --bytemd-mermaid-activation-border-color: #81B1DB;
+              --bytemd-mermaid-activation-bkg-color: hsl(180, 1.5873015873%, 28.3529411765%);
+              --bytemd-mermaid-sequence-number-color: black;
+              --bytemd-mermaid-alt-background: #555;
+              --bytemd-mermaid-class-text: #e0dfdf;
+              --bytemd-mermaid-c-scale0: #1f2020;
+              --bytemd-mermaid-c-scale1: #0b0000;
+              --bytemd-mermaid-c-scale2: #4d1037;
+              --bytemd-mermaid-c-scale3: #3f5258;
+              --bytemd-mermaid-c-scale4: #4f2f1b;
+              --bytemd-mermaid-c-scale5: #6e0a0a;
+              --bytemd-mermaid-c-scale6: #3b0048;
+              --bytemd-mermaid-c-scale7: #995a01;
+              --bytemd-mermaid-c-scale8: #154706;
+              --bytemd-mermaid-c-scale9: #161722;
+              --bytemd-mermaid-c-scale10: #00296f;
+              --bytemd-mermaid-c-scale11: #01629c;
+              --bytemd-mermaid-c-scale-inv0: #e0dfdf;
+              --bytemd-mermaid-c-scale-inv1: #f4ffff;
+              --bytemd-mermaid-c-scale-inv2: #b2efc8;
+              --bytemd-mermaid-c-scale-inv3: #c0ada7;
+              --bytemd-mermaid-c-scale-inv4: #b0d0e4;
+              --bytemd-mermaid-c-scale-inv5: #91f5f5;
+              --bytemd-mermaid-c-scale-inv6: #c4ffb7;
+              --bytemd-mermaid-c-scale-inv7: #66a5fe;
+              --bytemd-mermaid-c-scale-inv8: #eab8f9;
+              --bytemd-mermaid-c-scale-inv9: #e9e8dd;
+              --bytemd-mermaid-c-scale-inv10: #ffd690;
+              --bytemd-mermaid-c-scale-inv11: #fe9d63;
+              --bytemd-mermaid-c-scale-label0: lightgrey;
+              --bytemd-mermaid-c-scale-label1: lightgrey;
+              --bytemd-mermaid-c-scale-label2: lightgrey;
+              --bytemd-mermaid-c-scale-label3: lightgrey;
+              --bytemd-mermaid-c-scale-label4: lightgrey;
+              --bytemd-mermaid-c-scale-label5: lightgrey;
+              --bytemd-mermaid-c-scale-label6: lightgrey;
+              --bytemd-mermaid-c-scale-label7: lightgrey;
+              --bytemd-mermaid-c-scale-label8: lightgrey;
+              --bytemd-mermaid-c-scale-label9: lightgrey;
+              --bytemd-mermaid-c-scale-label10: lightgrey;
+              --bytemd-mermaid-c-scale-label11: lightgrey;
+            }
+            </style>
+            <!-- plugin-bytemd mermaid end -->
+            """;
+    }
+}


### PR DESCRIPTION
## What changed

- Added a ByteMD Mermaid plugin that renders fenced `mermaid` code blocks in the editor preview.
- Converts Mermaid code blocks into rendered SVG when emitting saved HTML content, so the frontend article page does not need to load Mermaid.
- Added responsive styling for rendered Mermaid SVG output.
- Added `mermaid@10.9.4` as a console dependency, loaded dynamically only when Mermaid content is present.

Fixes https://github.com/halo-sigs/plugin-bytemd/issues/44
Fixes https://github.com/halo-sigs/plugin-bytemd/issues/41

## Validation

- `pnpm build`
- `pnpm exec eslint src/plugins/mermaid.ts`

## Notes

`pnpm type-check` currently points to a missing `tsconfig.vitest.json`. Running `vue-tsc --noEmit -p tsconfig.json --composite false` also reports pre-existing project issues unrelated to this change: the existing `Editor` import rule and `@halo-dev/api-client` type resolution.
